### PR TITLE
Notify manager, when payment cancellation failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>quarkus-resteasy</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-mailer</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.java-doer</groupId>
             <artifactId>doer</artifactId>
             <version>0.0.13</version>

--- a/src/main/java/com/doertutorial/Order.java
+++ b/src/main/java/com/doertutorial/Order.java
@@ -1,5 +1,7 @@
 package com.doertutorial;
 
+import jakarta.json.JsonObject;
+
 import java.time.Instant;
 import java.util.UUID;
 
@@ -15,6 +17,7 @@ public class Order {
     private String reservationToken;
     private String paymentTransactionId;
     private String deliveryTrackingId;
+    private JsonObject failureDetails;
 
     public void assignFieldsFrom(Order other) {
         id = other.id;
@@ -28,6 +31,7 @@ public class Order {
         reservationToken = other.reservationToken;
         paymentTransactionId = other.paymentTransactionId;
         deliveryTrackingId = other.deliveryTrackingId;
+        failureDetails = other.failureDetails;
     }
 
     public UUID getId() {
@@ -116,6 +120,14 @@ public class Order {
 
     public void setDeliveryTrackingId(String deliveryTrackingId) {
         this.deliveryTrackingId = deliveryTrackingId;
+    }
+
+    public JsonObject getFailureDetails() {
+        return failureDetails;
+    }
+
+    public void setFailureDetails(JsonObject failureDetails) {
+        this.failureDetails = failureDetails;
     }
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 quarkus.flyway.migrate-at-start=true
 quarkus.rest-client.warehouse.url=http://localhost:8085/
 quarkus.rest-client.bankapi.url=http://localhost:8085/
-
+quarkus.mailer.from=doertutorial@local
+order.manager.email=order_manager@local

--- a/src/test/java/it/OrderProcessingITCase.java
+++ b/src/test/java/it/OrderProcessingITCase.java
@@ -5,6 +5,10 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
@@ -17,6 +21,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static it.Testbed.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OrderProcessingITCase {
     @BeforeEach
@@ -97,6 +102,67 @@ public class OrderProcessingITCase {
                 .body("order.rejectReason", equalTo("Unable to ship the order."))
                 .body("order.deliveryTrackingId", nullValue())
                 .body("task.status", nullValue());
+
+        verify(postRequestedFor(urlPathMatching("/warehouse/cancel"))
+                .withRequestBody(matchingJsonPath("token", WireMock.equalTo("mocked-token"))));
+        verify(postRequestedFor(urlPathMatching("/bank/cancelPayment"))
+                .withRequestBody(matchingJsonPath("transactionId", WireMock.equalTo("mocked-transactionId"))));
+    }
+
+    @Test
+    void notify_manager_when_payment_cancellation_failed() throws IOException {
+        stubFor(post("/warehouse/ship")
+                .willReturn(status(501)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"status\":\"Server failure\"}")));
+        stubFor(post("/bank/cancelPayment")
+                .willReturn(status(400)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"test-bank-system-error\":\"test-bank-system-error\"}")));
+
+        String location = RestAssured.with()
+                .redirects()
+                .follow(false)
+                .formParam("customer", "Alice")
+                .formParam("items", "a pen")
+                .post("/orders/submit")
+                .then()
+                .statusCode(303)
+                .extract()
+                .header("Location");
+
+        long taskId = waitForConditionOrDeadline(
+                () -> RestAssured.get(location).then().extract().jsonPath(),
+                json -> json.getString("task.failingSince") != null && !json.getBoolean("task.inProgress"),
+                Instant.now().plusSeconds(5)
+        ).getLong("task.id");
+
+        // Skip /warehouse/ship retries
+        makeTaskOlder(taskId, "10 min");
+
+        waitForConditionOrDeadline(
+                () -> RestAssured.get(location).then().extract().jsonPath(),
+                json -> json.getString("task.failingSince") != null && !json.getBoolean("task.inProgress") &&
+                        json.getString("order.rejectReason") != null,
+                Instant.now().plusSeconds(5)
+        );
+
+        // Skip /bank/cancelPayment retries
+        makeTaskOlder(taskId, "30 min");
+
+        waitForConditionOrDeadline(
+                () -> RestAssured.get(location).then(),
+                r -> r.extract().jsonPath().getString("task.status") == null,
+                Instant.now().plusSeconds(60)
+        ).statusCode(200)
+                .body("order.status", equalTo("REJECTED"))
+                .body("order.rejectReason", equalTo("Unable to ship the order."))
+                .body("order.deliveryTrackingId", nullValue())
+                .body("task.status", nullValue());
+
+        String logs = Files.readString(Path.of("target", "app-out.txt"), StandardCharsets.UTF_8);
+        assertTrue(logs.contains("from doertutorial@local to [integration-order-manager@test]"));
+        assertTrue(logs.contains("test-bank-system-error"));
 
         verify(postRequestedFor(urlPathMatching("/warehouse/cancel"))
                 .withRequestBody(matchingJsonPath("token", WireMock.equalTo("mocked-token"))));

--- a/src/test/java/it/Testbed.java
+++ b/src/test/java/it/Testbed.java
@@ -77,6 +77,8 @@ public class Testbed {
             env.put("QUARKUS_DATASOURCE_JDBC_URL", jdbcUrl);
             env.put("QUARKUS_DATASOURCE_USERNAME", "quarkus");
             env.put("QUARKUS_DATASOURCE_PASSWORD", "quarkus");
+            env.put("QUARKUS_MAILER_MOCK", "true");
+            env.put("ORDER_MANAGER_EMAIL", "integration-order-manager@test");
             app = builder.start();
             waitTextInFile(out, "Profile prod activated", Duration.ofMinutes(1));
             RestAssured.baseURI = "http://localhost";


### PR DESCRIPTION
If order shipping failed, the system should cancel payment. But payment cancellation itself may also fail. In that case the system should send email to manager, who then refund the payment manually.

![notify-manager](https://github.com/user-attachments/assets/388efa0a-ed71-4112-ac9c-df337b19fea9)

